### PR TITLE
Videos startups e balcao ajustado

### DIFF
--- a/lib/screens/catalogo_startups_screen.dart
+++ b/lib/screens/catalogo_startups_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import '../models/startup.dart';
 import '../services/startup_service.dart';
 import '../widgets/startup_card.dart';
+import '../widgets/startup_video_player.dart';
 import 'startup_detail_screen.dart';
 import 'profile_screen.dart';
 
@@ -102,6 +103,16 @@ class _CatalogoStartupsScreenState extends State<CatalogoStartupsScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const ProfileScreen()),
+    );
+  }
+
+  void _openStartupVideo(Startup startup) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => StartupVideoDialog(
+        startupName: startup.name,
+        videoPath: startup.videoDemo,
+      ),
     );
   }
 
@@ -245,6 +256,7 @@ class _CatalogoStartupsScreenState extends State<CatalogoStartupsScreen> {
                   ...startupsFiltradas.map(
                     (startup) => StartupCard(
                       startup: startup,
+                      onPlayVideo: () => _openStartupVideo(startup),
                       onTap: () {
                         Navigator.push(
                           context,

--- a/lib/screens/startup_detail_screen.dart
+++ b/lib/screens/startup_detail_screen.dart
@@ -12,6 +12,7 @@ import '../models/startup.dart';
 import '../models/pergunta_model.dart';
 import '../services/pergunta_service.dart';
 import '../services/public_pergunta_service.dart';
+import '../widgets/startup_video_player.dart';
 
 // Cores
 const _purple900 = Color(0xFF3A1C71);
@@ -521,6 +522,13 @@ class _StartupDetailScreenState extends State<StartupDetailScreen>
                     _buildStatusRow(),
                     const SizedBox(height: 20),
                     _buildSection('Sobre a Startup', _buildDescricao()),
+                    if (s.videoDemo.trim().isNotEmpty) ...[
+                      const SizedBox(height: 20),
+                      _buildSection(
+                        'Video demonstrativo',
+                        StartupVideoPlayer(videoPath: s.videoDemo),
+                      ),
+                    ],
                     const SizedBox(height: 20),
                     _buildSection('Captação & Tokens', _buildCaptacao()),
                     const SizedBox(height: 20),
@@ -1750,15 +1758,6 @@ class _StartupDetailScreenState extends State<StartupDetailScreen>
           _InfoRow(Icons.trending_up_rounded, 'Estágio', s.stage),
           const Divider(color: _divider, height: 24),
           _InfoRow(Icons.circle, 'Status', s.status),
-          if (s.videoDemo.isNotEmpty) ...[
-            const Divider(color: _divider, height: 24),
-            _InfoRow(
-              Icons.play_circle_outline_rounded,
-              'Demo',
-              s.videoDemo,
-              isLink: true,
-            ),
-          ],
         ],
       ),
     );
@@ -2043,8 +2042,7 @@ class _InfoRow extends StatelessWidget {
   final IconData icon;
   final String label;
   final String value;
-  final bool isLink;
-  const _InfoRow(this.icon, this.label, this.value, {this.isLink = false});
+  const _InfoRow(this.icon, this.label, this.value);
 
   @override
   Widget build(BuildContext context) {
@@ -2063,11 +2061,10 @@ class _InfoRow extends StatelessWidget {
             textAlign: TextAlign.end,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: TextStyle(
+            style: const TextStyle(
               fontSize: 14,
               fontWeight: FontWeight.w600,
-              color: isLink ? _accent : _textPrimary,
-              decoration: isLink ? TextDecoration.underline : null,
+              color: _textPrimary,
             ),
           ),
         ),

--- a/lib/screens/vender_token_screen.dart
+++ b/lib/screens/vender_token_screen.dart
@@ -9,14 +9,12 @@ import 'package:cloud_functions/cloud_functions.dart';
 import '../models/startup.dart';
 import '../repositories/startup_repository.dart';
 import '../services/mercado_service.dart';
+import 'startup_detail_screen.dart';
 
 class VenderTokenScreen extends StatefulWidget {
   final String userId;
 
-  const VenderTokenScreen({
-    super.key,
-    required this.userId,
-  });
+  const VenderTokenScreen({super.key, required this.userId});
 
   @override
   State<VenderTokenScreen> createState() => _VenderTokenScreenState();
@@ -69,7 +67,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
 
       final positions = List<Map<String, dynamic>>.from(
         (response['data'] as List).map(
-              (item) => Map<String, dynamic>.from(item),
+          (item) => Map<String, dynamic>.from(item),
         ),
       );
 
@@ -84,8 +82,8 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
         return;
       }
 
-      final availableQuantity =
-      (position.first['availableQuantity'] ?? 0).toInt();
+      final availableQuantity = (position.first['availableQuantity'] ?? 0)
+          .toInt();
 
       setState(() {
         _saldoDisponivel = availableQuantity;
@@ -119,9 +117,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
       _precoController.text.trim().replaceAll(',', '.'),
     );
 
-    final quantidade = int.tryParse(
-      _quantidadeController.text.trim(),
-    );
+    final quantidade = int.tryParse(_quantidadeController.text.trim());
 
     if (preco == null || preco <= 0) {
       _snack('Digite um preço válido.');
@@ -136,7 +132,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
     if (quantidade > _saldoDisponivel) {
       _snack(
         'Quantidade maior que seu saldo disponível '
-            '($_saldoDisponivel tokens).',
+        '($_saldoDisponivel tokens).',
       );
       return;
     }
@@ -146,14 +142,12 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
     final confirmar = await showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: const Text('Confirmar venda'),
         content: Text(
           'Colocar $quantidade token${quantidade > 1 ? 's' : ''} '
-              'de ${startup.name} à venda por R\$ ${preco.toStringAsFixed(2)} cada?\n\n'
-              'Total: R\$ ${(preco * quantidade).toStringAsFixed(2)}',
+          'de ${startup.name} à venda por R\$ ${preco.toStringAsFixed(2)} cada?\n\n'
+          'Total: R\$ ${(preco * quantidade).toStringAsFixed(2)}',
         ),
         actions: [
           TextButton(
@@ -195,10 +189,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
 
       if (!mounted) return;
 
-      _snack(
-        'Token colocado à venda com sucesso!',
-        success: true,
-      );
+      _snack('Token colocado à venda com sucesso!', success: true);
 
       Navigator.pop(context, true);
     } on FirebaseFunctionsException catch (e) {
@@ -223,6 +214,24 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
     );
   }
 
+  Future<void> _irParaCompraDaStartup() async {
+    final startup = _startupSelecionada;
+    if (startup == null) {
+      return;
+    }
+
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => StartupDetailScreen(startup: startup)),
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    await _carregarSaldo(startup.id);
+  }
+
   Widget _buildStartupList() {
     return FutureBuilder<List<Startup>>(
       future: _startupsFuture,
@@ -231,9 +240,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
           return const Center(
             child: Padding(
               padding: EdgeInsets.all(16),
-              child: CircularProgressIndicator(
-                color: Color(0xFF6A4CFF),
-              ),
+              child: CircularProgressIndicator(color: Color(0xFF6A4CFF)),
             ),
           );
         }
@@ -361,10 +368,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
       children: [
         const SizedBox(height: 8),
         Container(
-          padding: const EdgeInsets.symmetric(
-            horizontal: 14,
-            vertical: 10,
-          ),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
             color: _saldoDisponivel > 0
                 ? const Color(0xFFEDE7FF)
@@ -375,20 +379,20 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
             children: [
               _carregandoSaldo
                   ? const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: Color(0xFF6A4CFF),
-                ),
-              )
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Color(0xFF6A4CFF),
+                      ),
+                    )
                   : Icon(
-                Icons.token_rounded,
-                size: 16,
-                color: _saldoDisponivel > 0
-                    ? const Color(0xFF6A4CFF)
-                    : Colors.red,
-              ),
+                      Icons.token_rounded,
+                      size: 16,
+                      color: _saldoDisponivel > 0
+                          ? const Color(0xFF6A4CFF)
+                          : Colors.red,
+                    ),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
@@ -411,19 +415,38 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
             ],
           ),
         ),
+        if (!_carregandoSaldo && _saldoDisponivel == 0) ...[
+          const SizedBox(height: 12),
+          SizedBox(
+            width: double.infinity,
+            height: 46,
+            child: OutlinedButton.icon(
+              onPressed: _irParaCompraDaStartup,
+              icon: const Icon(Icons.shopping_cart_checkout_rounded, size: 18),
+              label: const Text(
+                'Comprar tokens desta startup',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF6A4CFF),
+                side: const BorderSide(color: Color(0xFF6A4CFF)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+            ),
+          ),
+        ],
         const SizedBox(height: 24),
       ],
     );
   }
 
   Widget _buildTotalPreview() {
-    final preco = double.tryParse(
-      _precoController.text.replaceAll(',', '.'),
-    );
+    final preco = double.tryParse(_precoController.text.replaceAll(',', '.'));
 
-    final quantidade = int.tryParse(
-      _quantidadeController.text,
-    );
+    final quantidade = int.tryParse(_quantidadeController.text);
 
     if (preco == null || quantidade == null || preco <= 0 || quantidade <= 0) {
       return const SizedBox.shrink();
@@ -442,10 +465,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
             const Expanded(
               child: Text(
                 'Total da oferta',
-                style: TextStyle(
-                  fontSize: 13,
-                  color: Color(0xFF6B7280),
-                ),
+                style: TextStyle(fontSize: 13, color: Color(0xFF6B7280)),
               ),
             ),
             Text(
@@ -464,7 +484,8 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final podeEnviar = !_enviando &&
+    final podeEnviar =
+        !_enviando &&
         !_carregandoSaldo &&
         _startupSelecionada != null &&
         _saldoDisponivel > 0;
@@ -476,10 +497,7 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
         foregroundColor: Colors.white,
         title: const Text(
           'Vender Token',
-          style: TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.w700,
-          ),
+          style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
         ),
         centerTitle: true,
         elevation: 0,
@@ -535,21 +553,21 @@ class _VenderTokenScreenState extends State<VenderTokenScreen> {
                 ),
                 label: _enviando
                     ? const SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: Colors.white,
-                  ),
-                )
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
                     : const Text(
-                  'Colocar à venda',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                    fontSize: 15,
-                  ),
-                ),
+                        'Colocar à venda',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w700,
+                          fontSize: 15,
+                        ),
+                      ),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: const Color(0xFF6A4CFF),
                   disabledBackgroundColor: Colors.grey.shade300,
@@ -609,10 +627,7 @@ class _InputField extends StatelessWidget {
       enabled: enabled,
       decoration: InputDecoration(
         hintText: hint,
-        hintStyle: const TextStyle(
-          color: Colors.black38,
-          fontSize: 14,
-        ),
+        hintStyle: const TextStyle(color: Colors.black38, fontSize: 14),
         filled: true,
         fillColor: enabled ? Colors.white : Colors.grey.shade100,
         contentPadding: const EdgeInsets.symmetric(
@@ -625,10 +640,7 @@ class _InputField extends StatelessWidget {
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(10),
-          borderSide: const BorderSide(
-            color: Color(0xFF6A4CFF),
-            width: 1.5,
-          ),
+          borderSide: const BorderSide(color: Color(0xFF6A4CFF), width: 1.5),
         ),
       ),
     );

--- a/lib/widgets/startup_card.dart
+++ b/lib/widgets/startup_card.dart
@@ -11,8 +11,14 @@ const _textSecondary = Color(0xFF6B7280);
 class StartupCard extends StatelessWidget {
   final Startup startup;
   final VoidCallback? onTap;
+  final VoidCallback? onPlayVideo;
 
-  const StartupCard({super.key, required this.startup, this.onTap});
+  const StartupCard({
+    super.key,
+    required this.startup,
+    this.onTap,
+    this.onPlayVideo,
+  });
 
   Color _getStageColor(String stage) {
     switch (stage.toLowerCase().trim()) {
@@ -277,6 +283,19 @@ class StartupCard extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(width: 4),
+                  if (startup.videoDemo.trim().isNotEmpty) ...[
+                    IconButton(
+                      tooltip: 'Ver video',
+                      onPressed: onPlayVideo,
+                      visualDensity: VisualDensity.compact,
+                      icon: const Icon(
+                        Icons.play_circle_fill_rounded,
+                        color: _purple600,
+                        size: 24,
+                      ),
+                    ),
+                    const SizedBox(width: 2),
+                  ],
                   const Icon(
                     Icons.chevron_right_rounded,
                     color: _textSecondary,

--- a/lib/widgets/startup_video_player.dart
+++ b/lib/widgets/startup_video_player.dart
@@ -1,0 +1,277 @@
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+const _purple600 = Color(0xFF6A4CFF);
+const _textSecondary = Color(0xFF6B7280);
+
+class StartupVideoPlayer extends StatefulWidget {
+  final String videoPath;
+
+  const StartupVideoPlayer({super.key, required this.videoPath});
+
+  @override
+  State<StartupVideoPlayer> createState() => _StartupVideoPlayerState();
+}
+
+class _StartupVideoPlayerState extends State<StartupVideoPlayer> {
+  VideoPlayerController? _controller;
+  bool _loading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadVideo();
+  }
+
+  @override
+  void didUpdateWidget(covariant StartupVideoPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.videoPath != widget.videoPath) {
+      _controller?.dispose();
+      _controller = null;
+      _loading = true;
+      _errorMessage = null;
+      _loadVideo();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadVideo() async {
+    final source = widget.videoPath.trim();
+
+    if (source.isEmpty) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _errorMessage = 'Video nao informado.';
+      });
+      return;
+    }
+
+    try {
+      final url = await _resolveVideoUrl(source);
+      final controller = VideoPlayerController.networkUrl(Uri.parse(url));
+
+      await controller.initialize();
+      controller.addListener(_refreshPlayerState);
+
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+
+      setState(() {
+        _controller = controller;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _errorMessage = 'Nao foi possivel carregar o video.';
+      });
+    }
+  }
+
+  Future<String> _resolveVideoUrl(String source) async {
+    final uri = Uri.tryParse(source);
+    if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+      return source;
+    }
+
+    return FirebaseStorage.instance.ref(source).getDownloadURL();
+  }
+
+  void _refreshPlayerState() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> _togglePlay() async {
+    final controller = _controller;
+    if (controller == null) return;
+
+    if (controller.value.isPlaying) {
+      await controller.pause();
+    } else {
+      await controller.play();
+    }
+
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return _VideoFrame(
+        child: const Center(
+          child: CircularProgressIndicator(color: _purple600),
+        ),
+      );
+    }
+
+    if (_errorMessage != null) {
+      return _VideoFrame(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              _errorMessage!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    final controller = _controller;
+    if (controller == null || !controller.value.isInitialized) {
+      return const SizedBox.shrink();
+    }
+
+    return _VideoFrame(
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          AspectRatio(
+            aspectRatio: controller.value.aspectRatio,
+            child: VideoPlayer(controller),
+          ),
+          Positioned.fill(
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: _togglePlay,
+                child: AnimatedOpacity(
+                  opacity: controller.value.isPlaying ? 0 : 1,
+                  duration: const Duration(milliseconds: 160),
+                  child: Center(
+                    child: Container(
+                      width: 62,
+                      height: 62,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.55),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.play_arrow_rounded,
+                        color: Colors.white,
+                        size: 42,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: VideoProgressIndicator(
+              controller,
+              allowScrubbing: true,
+              colors: const VideoProgressColors(
+                playedColor: _purple600,
+                bufferedColor: Color(0x99FFFFFF),
+                backgroundColor: Color(0x33000000),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class StartupVideoDialog extends StatelessWidget {
+  final String startupName;
+  final String videoPath;
+
+  const StartupVideoDialog({
+    super.key,
+    required this.startupName,
+    required this.videoPath,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.all(18),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    startupName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Fechar',
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(Icons.close_rounded),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            StartupVideoPlayer(videoPath: videoPath),
+            const SizedBox(height: 8),
+            const Text(
+              'Video demonstrativo da startup',
+              style: TextStyle(
+                color: _textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _VideoFrame extends StatelessWidget {
+  final Widget child;
+
+  const _VideoFrame({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        width: double.infinity,
+        constraints: const BoxConstraints(minHeight: 190),
+        color: Colors.black,
+        child: AspectRatio(aspectRatio: 16 / 9, child: child),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -208,6 +216,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:
@@ -284,10 +300,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   nested:
     dependency: transitive
     description:
@@ -389,6 +405,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.7"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.7.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -407,4 +463,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   provider: ^6.1.2
   mask_text_input_formatter: ^2.9.0
   http: ^1.6.0
+  video_player: ^2.11.1
  
 
 dev_dependencies:


### PR DESCRIPTION
## O que foi feito

-Balcão de Negociação ajustado com investidor podendo comprar apenas parte dos tokens que estão em oferta, não obrigatoriamente todos.
- Adiciona suporte a vídeos das startups usando Firebase Storage.
- Cria player reutilizável para carregar `videoDemo` como caminho do Storage.
- Adiciona botão de play no card do catálogo.
- Exibe o vídeo demonstrativo na tela de detalhes da startup.
- Adiciona dependência `video_player`.

## Como testar

- No Firestore, preencher `videoDemo` com um caminho como:
  `startups/startup_1/videos/demo.mp4`
- Abrir o catálogo.
- Clicar no botão de play no card da startup.
- Abrir o detalhe da startup e conferir a seção "Video demonstrativo".

## Validações

- `flutter analyze`
- `flutter test`
- `npm --prefix functions run build`